### PR TITLE
added support for svg "image" element

### DIFF
--- a/src/inlineImage.js
+++ b/src/inlineImage.js
@@ -5,11 +5,14 @@ var util = require('./util');
 
 var encodeImageAsDataURI = function (image, options) {
     var url = null;
-    if(!!image.attributes.src){
-        url = image.attributes.src.value;
+    if(image.hasAttribute('src')){
+        url = image.getAttribute('src');
     }
-    else if(!!image.attributes.href){
-        url = image.attributes.href.value;
+    else if(image.hasAttributeNS('http://www.w3.org/1999/xlink','href')){
+        url = image.getAttributeNS('http://www.w3.org/1999/xlink','href');
+    }
+    else if(image.hasAttribute('href')){
+        url = image.getAttribute('href');
     }
     var documentBase = util.getDocumentBaseUrl(image.ownerDocument),
         ajaxOptions = util.clone(options);
@@ -33,11 +36,14 @@ var encodeImageAsDataURI = function (image, options) {
 var filterExternalImages = function (images) {
     return images.filter(function (image) {
         var url = null;
-        if(!!image.attributes.src){
-            url = image.attributes.src.value;
+        if(image.hasAttribute('src')){
+            url = image.getAttribute('src');
         }
-        else if(!!image.attributes.href){
-            url = image.attributes.href.value;
+        else if(image.hasAttributeNS('http://www.w3.org/1999/xlink','href')){
+            url = image.getAttributeNS('http://www.w3.org/1999/xlink','href');
+        }
+        else if(image.hasAttribute('href')){
+            url = image.getAttribute('href');
         }
 
         return url !== null && !util.isDataUri(url);
@@ -65,11 +71,14 @@ exports.inline = function (doc, options) {
 
     return util.collectAndReportErrors(externalImages.map(function (image) {
         return encodeImageAsDataURI(image, options).then(function (dataURI) {
-            if(!!image.attributes.src){
-                image.attributes.src.value = dataURI;
+            if(image.hasAttribute('src')){
+                image.setAttribute('src', dataURI);
             }
-            else if(!!image.attributes.href){
-                image.attributes.href.value = dataURI;
+            else if(image.hasAttributeNS('http://www.w3.org/1999/xlink','href')){
+                image.setAttributeNS('http://www.w3.org/1999/xlink','href', dataURI);
+            }
+            else if(image.hasAttribute('href')){
+                url = image.setAttribute('href', dataURI);
             }
         });
     }));

--- a/src/inlineImage.js
+++ b/src/inlineImage.js
@@ -71,14 +71,14 @@ exports.inline = function (doc, options) {
 
     return util.collectAndReportErrors(externalImages.map(function (image) {
         return encodeImageAsDataURI(image, options).then(function (dataURI) {
-            if(image.hasAttribute('src')){
-                image.setAttribute('src', dataURI);
+            if(!!image.attributes.src){
+                image.attributes.src.value = dataURI;
             }
-            else if(image.hasAttributeNS('http://www.w3.org/1999/xlink','href')){
-                image.setAttributeNS('http://www.w3.org/1999/xlink','href', dataURI);
+            else if(!!image.attributes['xlink:href']){
+                image.attributes['xlink:href'].value = dataURI;
             }
-            else if(image.hasAttribute('href')){
-                url = image.setAttribute('href', dataURI);
+            else if(!!image.attributes.href){
+                image.attributes.href.value = dataURI;
             }
         });
     }));

--- a/test/specs/InlineImagesSpec.js
+++ b/test/specs/InlineImagesSpec.js
@@ -155,6 +155,36 @@ describe("Image and image input inline", function () {
         expect(getDataURIForImageURLSpy).toHaveBeenCalledWith(jasmine.any(String), {});
     });
 
+    it("should load an external svg image without xlink ns", function (done) {
+        mockGetDataURIForImageURL(firstImage, firstImageDataURI);
+        doc.body.innerHTML = (
+            '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="100" height="100" viewBox="0 0 100 100">'+
+            	'<image id="image" width="100" height="100" href="' + firstImage + '"></image>'+
+            '</svg>'
+        );
+
+        inlineImage.inline(doc, {}).then(function () {
+            expect(doc.getElementById("image").getAttribute('href')).toEqual(firstImageDataURI);
+
+            done();
+        });
+    });
+
+    it("should load an external svg image with xlink ns", function (done) {
+        mockGetDataURIForImageURL(secondImage, secondImageDataURI);
+        doc.body.innerHTML = (
+            '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="100" height="100" viewBox="0 0 100 100" xmlns:xlink="http://www.w3.org/1999/xlink">'+
+            	'<image id="image2" width="100" height="100" xlink:href="' + secondImage + '"></image>'+
+            '</svg>'
+        );
+
+        inlineImage.inline(doc, {}).then(function () {
+            expect(doc.getElementById("image2").getAttributeNS('http://www.w3.org/1999/xlink','href')).toEqual(secondImageDataURI);
+
+            done();
+        });
+    });
+
     describe("on errors", function () {
         var imageThatDoesExist = "image_that_does_exist.png";
 


### PR DESCRIPTION
iv been using rasterizeHTML to render svg / html to canvas but when ever i put a `<image/>` in any svg it would fail to load it, i tracked the loading of images back to this library.

if possible could you review / build the code on your end, because i cant seem to get the tests to run.

id like to fix this bug ASAP because i need this library and rasterizeHTML for my current project.

thanks.