### PR TITLE
add support for unicode-range in font-face definitions

### DIFF
--- a/src/cssSupport.js
+++ b/src/cssSupport.js
@@ -61,6 +61,11 @@ exports.changeFontFaceRuleSrc = function (cssRules, rule, newSrc) {
       "font-weight: " + rule.style.getPropertyValue("font-weight") + "; ";
   }
 
+  if (rule.style.getPropertyValue("unicode-range")) {
+    newRuleText +=
+      "unicode-range: " + rule.style.getPropertyValue("unicode-range") + "; ";
+  }
+
   newRuleText += "src: " + newSrc + "}";
   exports.exchangeRule(cssRules, rule, newRuleText);
 };


### PR DESCRIPTION
This adds support for the unicode-ranges property of font-faces

I'm using emoji-fonts, and use unicode-ranges to restrict what codepoints are affected by that emoji-font.
these unicode-ranges were ignored when printing using rasterizeHTML. This Fixes that problem :)