### PR TITLE
Accept nonce when inlining to comply with Content Security Policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /node_modules
 /build
 /dist/
+.idea/

--- a/src/cssSupport.js
+++ b/src/cssSupport.js
@@ -15,12 +15,19 @@ exports.unquoteString = function (quotedUrl) {
     }
 };
 
-exports.rulesForCssText = function (styleContent) {
+exports.rulesForCssText = function (styleContent, options) {
     var doc = document.implementation.createHTMLDocument(""),
         styleElement = document.createElement("style"),
         rules;
 
     styleElement.textContent = styleContent;
+
+    if (options.nonce) {
+        styleElement.nonce = options.nonce;
+    } else if (options.integrity) {
+        styleElement.setAttribute("integrity", options.integrity);
+    }
+
     // the style will only be parsed once it is added to a document
     doc.body.appendChild(styleElement);
     rules = styleElement.sheet.cssRules;
@@ -34,18 +41,18 @@ exports.cssRulesToText = function (cssRules) {
     }, "");
 };
 
-exports.exchangeRule = function (cssRules, rule, newRuleText) {
+exports.exchangeRule = function (cssRules, rule, newRuleText, options) {
     var ruleIdx = cssRules.indexOf(rule);
 
     // We create a new document and stylesheet to parse the rule,
     // instead of relying on rule.parentStyleSheet, because
     // rule.parentStyleSheet may be null
     // (https://github.com/cburgmer/inlineresources/issues/3)
-    cssRules[ruleIdx] = exports.rulesForCssText(newRuleText)[0];
+    cssRules[ruleIdx] = exports.rulesForCssText(newRuleText, options)[0];
 };
 
 // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=443978
-exports.changeFontFaceRuleSrc = function (cssRules, rule, newSrc) {
+exports.changeFontFaceRuleSrc = function (cssRules, rule, newSrc, options) {
     var newRuleText =
         "@font-face { font-family: " +
         rule.style.getPropertyValue("font-family") +
@@ -69,5 +76,5 @@ exports.changeFontFaceRuleSrc = function (cssRules, rule, newSrc) {
     }
 
     newRuleText += "src: " + newSrc + "}";
-    exports.exchangeRule(cssRules, rule, newRuleText);
+    exports.exchangeRule(cssRules, rule, newRuleText, options);
 };

--- a/src/cssSupport.js
+++ b/src/cssSupport.js
@@ -24,8 +24,6 @@ exports.rulesForCssText = function (styleContent, options) {
 
     if (options && options.nonce) {
         styleElement.nonce = options.nonce;
-    } else if (options && options.integrity) {
-        styleElement.setAttribute("integrity", options.integrity);
     }
 
     // the style will only be parsed once it is added to a document

--- a/src/cssSupport.js
+++ b/src/cssSupport.js
@@ -22,9 +22,9 @@ exports.rulesForCssText = function (styleContent, options) {
 
     styleElement.textContent = styleContent;
 
-    if (options.nonce) {
+    if (options && options.nonce) {
         styleElement.nonce = options.nonce;
-    } else if (options.integrity) {
+    } else if (options && options.integrity) {
         styleElement.setAttribute("integrity", options.integrity);
     }
 

--- a/src/inline.js
+++ b/src/inline.js
@@ -45,7 +45,7 @@ var requestExternalsForStylesheet = function (
     alreadyLoadedCssUrls,
     options
 ) {
-    var cssRules = cssSupport.rulesForCssText(styleContent);
+    var cssRules = cssSupport.rulesForCssText(styleContent, options);
 
     return inlineCss
         .loadCSSImportsForRules(cssRules, alreadyLoadedCssUrls, options)
@@ -150,7 +150,7 @@ var requestStylesheetAndInlineResources = function (url, options) {
     return util
         .ajax(url, options)
         .then(function (content) {
-            var cssRules = cssSupport.rulesForCssText(content);
+            var cssRules = cssSupport.rulesForCssText(content, options);
 
             return {
                 content: content,
@@ -159,7 +159,11 @@ var requestStylesheetAndInlineResources = function (url, options) {
         })
         .then(function (result) {
             var hasChangesFromPathAdjustment =
-                inlineCss.adjustPathsOfCssResources(url, result.cssRules);
+                inlineCss.adjustPathsOfCssResources(
+                    url,
+                    result.cssRules,
+                    options
+                );
 
             return {
                 content: result.content,

--- a/src/inlineCss.js
+++ b/src/inlineCss.js
@@ -82,7 +82,7 @@ var findExternalFontFaceUrls = function (parsedFontFaceSources) {
     return sourceIndices;
 };
 
-exports.adjustPathsOfCssResources = function (baseUrl, cssRules) {
+exports.adjustPathsOfCssResources = function (baseUrl, cssRules, options) {
     var backgroundRules = findBackgroundImageRules(cssRules),
         backgroundDeclarations = findBackgroundDeclarations(backgroundRules),
         change = false;
@@ -138,7 +138,11 @@ exports.adjustPathsOfCssResources = function (baseUrl, cssRules) {
             cssSupport.changeFontFaceRuleSrc(
                 cssRules,
                 rule,
-                fontFaceSrcValueParser.serialize(parsedFontFaceSources)
+                fontFaceSrcValueParser.serialize(
+                    parsedFontFaceSources,
+                    options
+                ),
+                options
             );
 
             change = true;
@@ -148,7 +152,12 @@ exports.adjustPathsOfCssResources = function (baseUrl, cssRules) {
         var cssUrl = rule.href,
             url = util.joinUrl(baseUrl, cssUrl);
 
-        cssSupport.exchangeRule(cssRules, rule, "@import url(" + url + ");");
+        cssSupport.exchangeRule(
+            cssRules,
+            rule,
+            "@import url(" + url + ");",
+            options
+        );
 
         change = true;
     });
@@ -191,7 +200,7 @@ var loadAndInlineCSSImport = function (
 
     return util.ajax(url, options).then(
         function (cssText) {
-            var externalCssRules = cssSupport.rulesForCssText(cssText);
+            var externalCssRules = cssSupport.rulesForCssText(cssText, options);
 
             // Recursively follow @import statements
             return exports
@@ -201,7 +210,11 @@ var loadAndInlineCSSImport = function (
                     options
                 )
                 .then(function (result) {
-                    exports.adjustPathsOfCssResources(url, externalCssRules);
+                    exports.adjustPathsOfCssResources(
+                        url,
+                        externalCssRules,
+                        options
+                    );
 
                     substituteRule(cssRules, rule, externalCssRules);
 
@@ -390,7 +403,8 @@ var iterateOverRulesAndInlineFontFace = function (cssRules, options) {
                         cssSupport.changeFontFaceRuleSrc(
                             cssRules,
                             rule,
-                            result.srcDeclarationValue
+                            result.srcDeclarationValue,
+                            options
                         );
 
                         hasChanges = true;

--- a/test/specs/InlineCssLinksSpec.js
+++ b/test/specs/InlineCssLinksSpec.js
@@ -346,7 +346,7 @@ describe("Inline CSS links", function () {
                 expect(adjustPathsOfCssResourcesSpy).toHaveBeenCalledWith(
                     "below/some.css",
                     jasmine.any(Object),
-                    undefined
+                    { baseUrl: "some_url/" }
                 );
 
                 done();

--- a/test/specs/InlineCssLinksSpec.js
+++ b/test/specs/InlineCssLinksSpec.js
@@ -345,7 +345,8 @@ describe("Inline CSS links", function () {
             .then(function () {
                 expect(adjustPathsOfCssResourcesSpy).toHaveBeenCalledWith(
                     "below/some.css",
-                    jasmine.any(Object)
+                    jasmine.any(Object),
+                    undefined
                 );
 
                 done();

--- a/test/specs/InlineCssSpec.js
+++ b/test/specs/InlineCssSpec.js
@@ -443,7 +443,7 @@ describe("Inline CSS content", function () {
                 expect(adjustPathsOfCssResourcesSpy).toHaveBeenCalledWith(
                     "url_base/that.css",
                     jasmine.any(Object),
-                    undefined
+                    {}
                 );
                 expect(
                     adjustPathsOfCssResourcesSpy.calls

--- a/test/specs/InlineCssSpec.js
+++ b/test/specs/InlineCssSpec.js
@@ -442,7 +442,8 @@ describe("Inline CSS content", function () {
             inlineCss.loadCSSImportsForRules(rules, [], {}).then(function () {
                 expect(adjustPathsOfCssResourcesSpy).toHaveBeenCalledWith(
                     "url_base/that.css",
-                    jasmine.any(Object)
+                    jasmine.any(Object),
+                    undefined
                 );
                 expect(
                     adjustPathsOfCssResourcesSpy.calls


### PR DESCRIPTION
Accept nonce when inlining to comply with `Content-Security-Policy` header. I'll update the wiki with the new option if this gets merged.

I'll use these changes in [this PR](https://github.com/mui/mui-x/pull/20053) to fix [an issue](https://github.com/mui/mui-x/issues/20037) a user is having when exporting MUI X Charts with a Content Security Policy that requires a nonce.


Note: I noticed the test `Inline CSS content loadAndInlineCSSResourcesForRules on font-face should ignore an invalid source together with a valid one` is failing in this PR, but it's also failing in `master`, so I didn't update it. 

