### PR TITLE
Fix `loadAndInlineCssLinks` not inserting the provided nonce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inlineresources",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inlineresources",
-      "version": "1.0.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "css-font-face-src": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inlineresources",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "Inlines style sheets, images, fonts and scripts in HTML documents. Works in the browser.",
   "keywords": [
     "inline",
@@ -11,7 +11,7 @@
     "CSS",
     "webfonts"
   ],
-  "homepage": "http://www.github.com/cburgmer/inlineresources",
+  "homepage": "https://www.github.com/cburgmer/inlineresources",
   "bugs": "https://github.com/cburgmer/inlineresources/issues",
   "license": "MIT",
   "author": {

--- a/src/inline.js
+++ b/src/inline.js
@@ -128,7 +128,7 @@ exports.loadAndInlineStyles = function (doc, options) {
 
 /* CSS link inlining */
 
-var substituteLinkWithInlineStyle = function (oldLinkNode, styleContent) {
+var substituteLinkWithInlineStyle = function (oldLinkNode, styleContent, options) {
     var parent = oldLinkNode.parentNode,
         styleNode;
 
@@ -136,6 +136,11 @@ var substituteLinkWithInlineStyle = function (oldLinkNode, styleContent) {
     if (styleContent) {
         styleNode = oldLinkNode.ownerDocument.createElement("style");
         styleNode.type = "text/css";
+
+        if (options && options.nonce) {
+            styleNode.nonce = options.nonce;
+        }
+
         styleNode.appendChild(
             oldLinkNode.ownerDocument.createTextNode(styleContent)
         );
@@ -251,7 +256,7 @@ exports.loadAndInlineCssLinks = function (doc, options) {
         links.map(function (link) {
             return loadLinkedCSS(link, options).then(
                 function (result) {
-                    substituteLinkWithInlineStyle(link, result.content + "\n");
+                    substituteLinkWithInlineStyle(link, result.content + "\n", options);
 
                     errors = errors.concat(result.errors);
                 },


### PR DESCRIPTION
Fix `loadAndInlineCssLinks` not inserting the provided nonce.

